### PR TITLE
exit if mock servers fail to start

### DIFF
--- a/test/acceptance/coffee/helpers/MockDocUpdaterServer.coffee
+++ b/test/acceptance/coffee/helpers/MockDocUpdaterServer.coffee
@@ -38,5 +38,9 @@ module.exports = MockDocUpdaterServer =
 		app.listen 3003, (error) ->
 			MockDocUpdaterServer.running = true
 			callback(error)
+		.on "error", (error) ->
+			console.error "error starting MockDocUpdaterServer:", error.message
+			process.exit(1)
+
 			
 sinon.spy MockDocUpdaterServer, "getDocument"

--- a/test/acceptance/coffee/helpers/MockWebServer.coffee
+++ b/test/acceptance/coffee/helpers/MockWebServer.coffee
@@ -35,5 +35,9 @@ module.exports = MockWebServer =
 		app.listen 3000, (error) ->
 			MockWebServer.running = true
 			callback(error)
+		.on "error", (error) ->
+			console.error "error starting MockWebServer:", error.message
+			process.exit(1)
+
 			
 sinon.spy MockWebServer, "joinProject"


### PR DESCRIPTION
avoid confusion if existing process is already listening on the port