### PR TITLE
Provide hosts as environment settings and add npm run start script

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -1,7 +1,7 @@
 module.exports =
 	redis:
 		realtime:
-			host: "localhost"
+			host: process.env['REDIS_HOST'] or "localhost"
 			port: "6379"
 			password: ""
 			key_schema:
@@ -9,35 +9,35 @@ module.exports =
 				connectedUser: ({project_id, client_id})-> "connected_user:#{project_id}:#{client_id}"
 
 		documentupdater:
-			host: "localhost"
+			host: process.env['REDIS_HOST'] or "localhost"
 			port: "6379"
 			password: ""
 			key_schema:
 				pendingUpdates: ({doc_id}) -> "PendingUpdates:#{doc_id}"
 
 		websessions:
-			host: "localhost"
+			host: process.env['REDIS_HOST'] or "localhost"
 			port: "6379"
 			password: ""
 
 	internal:
 		realTime:
 			port: 3026
-			host: "localhost"
+			host: process.env['LISTEN_ADDRESS'] or "localhost"
 			user: "sharelatex"
 			pass: "password"
 			
 	apis:
 		web:
-			url: "http://localhost:3000"
+			url: "http://#{process.env['WEB_HOST'] or "localhost"}:3000"
 			user: "sharelatex"
 			pass: "password"
 		documentupdater:
-			url: "http://localhost:3003"
+			url: "http://#{process.env['DOCUPDATER_HOST'] or "localhost"}:3003"
 			
 	security:
 		sessionSecret: "secret-please-change"
 		
-	cookieName:"sharelatex.sid"
+	cookieName: "sharelatex.sid"
 	
 	max_doc_length: 2 * 1024 * 1024 # 2mb

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "https://github.com/sharelatex/real-time-sharelatex.git"
   },
+  "scripts": {
+    "compile:app": "coffee -o app/js -c app/coffee && coffee -c app.coffee",
+    "start": "npm run compile:app && node app.js"
+  },
   "dependencies": {
     "async": "^0.9.0",
     "basic-auth-connect": "^1.0.0",


### PR DESCRIPTION
Makes this service compatible with https://github.com/sharelatex/sharelatex-dev-environment

Allows other service's locations to be passed in via environment variables which are provided by docker-compose.

Also provides an `npm run start` script as a common entry point to all services via docker-compose.