### PR TITLE
Switch dev env to use v2 port instead of SL

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -29,7 +29,7 @@ module.exports =
 			
 	apis:
 		web:
-			url: "http://#{process.env['WEB_HOST'] or "localhost"}:3000"
+			url: "http://#{process.env['WEB_HOST'] or "localhost"}:#{process.env['WEB_PORT'] or 3000}"
 			user: "sharelatex"
 			pass: "password"
 		documentupdater:


### PR DESCRIPTION
### Description

Switches dev environment to use web_v2 container instead of web_sl container now that the SL container is not needed in most dev workflows.

### Related Issues / PRs
Connects to sharelatex/sharelatex-dev-environment#121