### PR TITLE
Nameless logged in user labelled as anonymous

### DIFF
--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -52,6 +52,10 @@ module.exports = WebsocketController =
 		metrics.inc "editor.leave-project"
 		Utils.getClientAttributes client, ["project_id", "user_id"], (error, {project_id, user_id}) ->
 			return callback(error) if error?
+
+			logger.log {project_id, user_id, client_id: client.id}, "client leaving project"
+			WebsocketLoadBalancer.emitToRoom project_id, "clientTracking.clientDisconnected", client.id
+			
 			# bail out if the client had not managed to authenticate or join
 			# the project.  Prevents downstream errors in docupdater from
 			# flushProjectToMongoAndDelete with null project_id.
@@ -61,9 +65,6 @@ module.exports = WebsocketController =
 			if not project_id?
 				logger.log {user_id: user_id, client_id: client.id}, "client leaving, not in project"
 				return callback()
-
-			logger.log {project_id, user_id, client_id: client.id}, "client leaving project"
-			WebsocketLoadBalancer.emitToRoom project_id, "clientTracking.clientDisconnected", client.id
 		
 			# We can do this in the background
 			ConnectedUsersManager.markUserAsDisconnected project_id, client.id, (err) ->
@@ -144,13 +145,18 @@ module.exports = WebsocketController =
 				cursorData.id      = client.id
 				cursorData.user_id = user_id if user_id?
 				cursorData.email   = email   if email?
-				if first_name or last_name
+				if !user_id or user_id == 'anonymous-user'
+					cursorData.name = ""
+					callback()
+				else 
 					cursorData.name = if first_name && last_name
 						"#{first_name} #{last_name}"
 					else if first_name
 						first_name
 					else if last_name
 						last_name
+					else
+						""
 					ConnectedUsersManager.updateUserPosition(project_id, client.id, {
 						first_name: first_name,
 						last_name:  last_name,
@@ -160,10 +166,7 @@ module.exports = WebsocketController =
 						row:    cursorData.row,
 						column: cursorData.column,
 						doc_id: cursorData.doc_id
-					}, callback)
-				else
-					cursorData.name = ""
-					callback()
+					}, callback)					
 				WebsocketLoadBalancer.emitToRoom(project_id, "clientTracking.clientUpdated", cursorData)
 
 	getConnectedUsers: (client, callback = (error, users) ->) ->

--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -137,7 +137,7 @@ module.exports = WebsocketController =
 		], (error, {project_id, first_name, last_name, email, user_id}) ->
 			return callback(error) if error?
 			logger.log {user_id, project_id, client_id: client.id, cursorData: cursorData}, "updating client position"
-					
+
 			AuthorizationManager.assertClientCanViewProjectAndDoc client, cursorData.doc_id, (error) ->
 				if error?
 					logger.warn {err: error, client_id: client.id, project_id, user_id}, "silently ignoring unauthorized updateClientPosition. Client likely hasn't called joinProject yet."
@@ -145,10 +145,11 @@ module.exports = WebsocketController =
 				cursorData.id      = client.id
 				cursorData.user_id = user_id if user_id?
 				cursorData.email   = email   if email?
+				# Don't store anonymous users in redis to avoid influx
 				if !user_id or user_id == 'anonymous-user'
 					cursorData.name = ""
 					callback()
-				else 
+				else
 					cursorData.name = if first_name && last_name
 						"#{first_name} #{last_name}"
 					else if first_name
@@ -166,7 +167,7 @@ module.exports = WebsocketController =
 						row:    cursorData.row,
 						column: cursorData.column,
 						doc_id: cursorData.doc_id
-					}, callback)					
+					}, callback)
 				WebsocketLoadBalancer.emitToRoom(project_id, "clientTracking.clientUpdated", cursorData)
 
 	getConnectedUsers: (client, callback = (error, users) ->) ->

--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -145,26 +145,24 @@ module.exports = WebsocketController =
 				cursorData.id      = client.id
 				cursorData.user_id = user_id if user_id?
 				cursorData.email   = email   if email?
-				if first_name or last_name
-					cursorData.name = if first_name && last_name
-						"#{first_name} #{last_name}"
-					else if first_name
-						first_name
-					else if last_name
-						last_name
-					ConnectedUsersManager.updateUserPosition(project_id, client.id, {
-						first_name: first_name,
-						last_name:  last_name,
-						email:      email,
-						_id:        user_id
-					}, {
-						row:    cursorData.row,
-						column: cursorData.column,
-						doc_id: cursorData.doc_id
-					}, callback)
+				cursorData.name = if first_name && last_name
+					"#{first_name} #{last_name}"
+				else if first_name
+					first_name
+				else if last_name
+					last_name
 				else
-					cursorData.name = "Anonymous"
-					callback()
+					""
+				ConnectedUsersManager.updateUserPosition(project_id, client.id, {
+					first_name: first_name,
+					last_name:  last_name,
+					email:      email,
+					_id:        user_id
+				}, {
+					row:    cursorData.row,
+					column: cursorData.column,
+					doc_id: cursorData.doc_id
+				}, callback)
 				WebsocketLoadBalancer.emitToRoom(project_id, "clientTracking.clientUpdated", cursorData)
 
 	getConnectedUsers: (client, callback = (error, users) ->) ->

--- a/test/unit/coffee/WebsocketControllerTests.coffee
+++ b/test/unit/coffee/WebsocketControllerTests.coffee
@@ -554,6 +554,10 @@ describe 'WebsocketController', ->
 					})
 					.should.equal true
 
+			it "should not send cursor data to the connected user manager", (done)->
+				@ConnectedUsersManager.updateUserPosition.called.should.equal false
+				done()
+
 	describe "applyOtUpdate", ->
 		beforeEach ->
 			@update = {op: {p: 12, t: "foo"}}


### PR DESCRIPTION
### Description

If a user joins in the middle of a user's session and they have neither first name nor last name set, they were labelled as Anonymous instead of by their email address as they should be.

Sends an empty string for the user's name instead of "Anonymous". Users who are truly anonymous are dealt with in web (See related PR).

#### Related Issues / PRs

Fixes https://github.com/sharelatex/web-sharelatex-internal/issues/910

Relates to https://github.com/sharelatex/web-sharelatex-internal/pull/1501

### Review

#### Manual Testing Performed

- [X] Truly anonymous user appears and is labelled as 'Anonymous'
- [X] Logged in user with no name appears and is labelled with their email address

### Deployment

Deploy the web one first https://github.com/sharelatex/web-sharelatex-internal/pull/1501

#### Who Needs to Know?

@jdleesmiller was pairing with me on it at one point so he will probably be interested in what happened with it in the end
