### PR TITLE
Fix test to accommodate changes to anonymous users

### DIFF
--- a/test/acceptance/coffee/ClientTrackingTests.coffee
+++ b/test/acceptance/coffee/ClientTrackingTests.coffee
@@ -141,6 +141,6 @@ describe "clientTracking", ->
 					doc_id: @doc_id
 					id: @anonymous.socket.sessionid
 					user_id: "anonymous-user"
-					name: "Anonymous"
+					name: ""
 				}
 			]


### PR DESCRIPTION
Fix this failing acceptance test

```
  1 failing

  1) clientTracking
       when an anonymous client updates its cursor location
         should tell other clients about the update:

      AssertionError: expected [ Array(1) ] to deeply equal [ Array(1) ]
      + expected - actual

         {
           "column": 36
           "doc_id": "463debbfb87ce56cf0cecb39"
           "id": "gLgdkM0T7x-yJRu6p1F-"
      -    "name": ""
      +    "name": "Anonymous"
           "row": 42
           "user_id": "anonymous-user"
         }
       ]
      
      at Assertion.assertEqual (node_modules/chai/lib/chai/core/assertions.js:393:19)
      at Assertion.ctx.(anonymous function) [as equal] (node_modules/chai/lib/chai/utils/addMethod.js:40:25)
      at Context.<anonymous> (test/acceptance/js/ClientTrackingTests.js:202:41)

```

Which happened as a result of the changes done to change how anonymous users are handled in `WebSocketController` in https://github.com/sharelatex/real-time-sharelatex/pull/35