### PR TITLE
setup continualPubsubTraffic to keep pub sub happy

### DIFF
--- a/app/coffee/DocumentUpdaterController.coffee
+++ b/app/coffee/DocumentUpdaterController.coffee
@@ -24,6 +24,8 @@ module.exports = DocumentUpdaterController =
 				DocumentUpdaterController._applyUpdateFromDocumentUpdater(io, message.doc_id, message.op)
 			else if message.error?
 				DocumentUpdaterController._processErrorFromDocumentUpdater(io, message.doc_id, message.error, message)
+			else if message.health_check?
+				logger.debug {message}, "got health check message in applied ops channel"
 
 	_applyUpdateFromDocumentUpdater: (io, doc_id, update) ->
 		for client in io.sockets.clients(doc_id)

--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -37,4 +37,6 @@ module.exports = WebsocketLoadBalancer =
 				io.sockets.emit(message.message, message.payload...)
 			else if message.room_id?
 				io.sockets.in(message.room_id).emit(message.message, message.payload...)
+			else if message.health_check?
+				logger.debug {message}, "got health check message in editor events channel"
 		

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -44,6 +44,8 @@ settings =
 
 	forceDrainMsDelay: process.env['FORCE_DRAIN_MS_DELAY'] or false
 
+	continualPubsubTraffic: process.env['CONTINUAL_PUBSUB_TRAFFIC'] or false
+
 	
 # console.log settings.redis
 module.exports = settings


### PR DESCRIPTION
### Description
this keeps the pub sub channel ticking along happily. Likely only an issue in staging but it means there is always traffic happening. I think the root cause is ghostunnel but this solves the issue to an adequate degree. 



#### Screenshots



#### Related Issues / PRs
https://github.com/sharelatex/overleaf-google-ops/issues/176


### Review



#### Potential Impact
Increases the amount of traffic through redis, but even with 30 instances it is only an extra 0.5ms which is nothing for redis.


#### Manual Testing Performed
updates on https://staging-google.sharelatex.com should keep working and not timeout

#### Accessibility



### Deployment



#### Deployment Checklist

#### Metrics and Monitoring



#### Who Needs to Know?
