### PR TITLE
handle duplicate entries in io.sockets.clients

### DIFF
--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -39,7 +39,12 @@ module.exports = WebsocketLoadBalancer =
 			else if message.room_id?
 				if message._id?
 					EventLogger.checkEventOrder("editor-events", message._id, message)
-				io.sockets.in(message.room_id).emit(message.message, message.payload...)
+				# send messages only to unique clients (due to duplicate entries in io.sockets.clients)
+				clientList = io.sockets.clients(message.room_id)
+				seen = {}
+				for client in clientList when not seen[client.id]
+					seen[client.id] = true
+					client.emit(message.message, message.payload...)
 			else if message.health_check?
 				logger.debug {message}, "got health check message in editor events channel"
 		

--- a/test/unit/coffee/DocumentUpdaterControllerTests.coffee
+++ b/test/unit/coffee/DocumentUpdaterControllerTests.coffee
@@ -23,6 +23,7 @@ describe "DocumentUpdaterController", ->
 			"./SafeJsonParse": @SafeJsonParse =
 				parse: (data, cb) => cb null, JSON.parse(data)
 			"./EventLogger": @EventLogger = {checkEventOrder: sinon.stub()}
+			"metrics-sharelatex": @metrics = {inc: sinon.stub()}
 
 	describe "listenForUpdatesFromDocumentUpdater", ->
 		beforeEach ->
@@ -81,7 +82,7 @@ describe "DocumentUpdaterController", ->
 				v: @version = 42
 				doc: @doc_id
 			@io.sockets =
-				clients: sinon.stub().returns([@sourceClient, @otherClients...])
+				clients: sinon.stub().returns([@sourceClient, @otherClients..., @sourceClient]) # include a duplicate client
 		
 		describe "normally", ->
 			beforeEach ->
@@ -91,6 +92,7 @@ describe "DocumentUpdaterController", ->
 				@sourceClient.emit
 					.calledWith("otUpdateApplied", v: @version, doc: @doc_id)
 					.should.equal true
+				@sourceClient.emit.calledOnce.should.equal true
 
 			it "should get the clients connected to the document", ->
 				@io.sockets.clients


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

We think this is the root cause of out of sync errors.  The socket.io library can get into a state where there are duplicate entries when iterating over the clients in a 'room', causing duplicate messages to be sent (https://github.com/overleaf/sharelatex/issues/1700, https://github.com/overleaf/sharelatex/issues/1632 and https://github.com/overleaf/sharelatex/issues/1627)

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/sharelatex/issues/1700

### Review

Keeps the same iteration but uses a `seen[id]` hash to skip sending messages to clients already seen.

#### Potential Impact

High

#### Manual Testing Performed

- [x] Unit and acceptance tests  (extended the unit tests to fail if duplicates are not removed)
- [x] Local dev env

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

Grafana realtime dashboard, new metric available `socket-io.duplicate-clients`

#### Who Needs to Know?

@jpallen @jdleesmiller 
