### PR TITLE
add health check to pubsub channels

### DIFF
--- a/app/coffee/DocumentUpdaterController.coffee
+++ b/app/coffee/DocumentUpdaterController.coffee
@@ -4,6 +4,7 @@ redis = require("redis-sharelatex")
 rclient = redis.createClient(settings.redis.documentupdater)
 SafeJsonParse = require "./SafeJsonParse"
 EventLogger = require "./EventLogger"
+HealthCheckManager = require "./HealthCheckManager"
 metrics = require "metrics-sharelatex"
 
 MESSAGE_SIZE_LOG_LIMIT = 1024 * 1024 # 1Mb
@@ -34,6 +35,7 @@ module.exports = DocumentUpdaterController =
 				DocumentUpdaterController._processErrorFromDocumentUpdater(io, message.doc_id, message.error, message)
 			else if message.health_check?
 				logger.debug {message}, "got health check message in applied ops channel"
+				HealthCheckManager.check channel, message.key
 
 	_applyUpdateFromDocumentUpdater: (io, doc_id, update) ->
 		clientList = io.sockets.clients(doc_id)

--- a/app/coffee/HealthCheckManager.coffee
+++ b/app/coffee/HealthCheckManager.coffee
@@ -1,0 +1,49 @@
+metrics = require "metrics-sharelatex"
+
+os = require "os"
+HOST = os.hostname()
+PID = process.pid
+COUNT = 0
+
+CHANNEL_MANAGER = {} # hash of event checkers by channel name
+CHANNEL_ERROR = {} # error status by channel name
+
+module.exports = class HealthCheckManager
+    # create an instance of this class which checks that an event with a unique
+    # id is received only once within a timeout
+    constructor: (@channel, timeout = 1000) ->
+        # unique event string
+        @id = "host=#{HOST}:pid=#{PID}:count=#{COUNT++}"
+        # count of number of times the event is received
+        @count = 0 
+        # after a timeout check the status of the count
+        @handler = setTimeout () =>
+            @setStatus()
+        , timeout
+        # use a timer to record the latency of the channel
+        @timer = new metrics.Timer("event.#{@channel}.latency")
+        # keep a record of these objects to dispatch on
+        CHANNEL_MANAGER[@channel] = @
+    processEvent: (id) ->
+        # if this is our event record it
+        if id == @id
+            @count++
+            @timer?.done()
+            @timer = null # only time the latency of the first event
+    setStatus: () ->
+        # if we saw the event anything other than a single time that is an error
+        error = (@count != 1)
+        CHANNEL_ERROR[@channel] = error
+
+    # class methods
+    @check: (channel, id) ->
+        # dispatch event to manager for channel
+        CHANNEL_MANAGER[channel]?.processEvent id
+    @status: () ->
+        # return status of all channels for logging
+        return CHANNEL_ERROR
+    @isFailing: () -> 
+        # check if any channel status is bad 
+        for channel, error of CHANNEL_ERROR
+            return true if error is true
+        return false

--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -5,6 +5,7 @@ SafeJsonParse = require "./SafeJsonParse"
 rclientPub = redis.createClient(Settings.redis.realtime)
 rclientSub = redis.createClient(Settings.redis.realtime)
 EventLogger = require "./EventLogger"
+HealthCheckManager = require "./HealthCheckManager"
 
 module.exports = WebsocketLoadBalancer =
 	rclientPub: rclientPub
@@ -53,4 +54,5 @@ module.exports = WebsocketLoadBalancer =
 					client.emit(message.message, message.payload...)
 			else if message.health_check?
 				logger.debug {message}, "got health check message in editor events channel"
+				HealthCheckManager.check channel, message.key
 		

--- a/test/unit/coffee/DocumentUpdaterControllerTests.coffee
+++ b/test/unit/coffee/DocumentUpdaterControllerTests.coffee
@@ -23,6 +23,7 @@ describe "DocumentUpdaterController", ->
 			"./SafeJsonParse": @SafeJsonParse =
 				parse: (data, cb) => cb null, JSON.parse(data)
 			"./EventLogger": @EventLogger = {checkEventOrder: sinon.stub()}
+			"./HealthCheckManager": {check: sinon.stub()}
 			"metrics-sharelatex": @metrics = {inc: sinon.stub()}
 
 	describe "listenForUpdatesFromDocumentUpdater", ->

--- a/test/unit/coffee/WebsocketLoadBalancerTests.coffee
+++ b/test/unit/coffee/WebsocketLoadBalancerTests.coffee
@@ -13,6 +13,7 @@ describe "WebsocketLoadBalancer", ->
 			"./SafeJsonParse": @SafeJsonParse =
 				parse: (data, cb) => cb null, JSON.parse(data)
 			"./EventLogger": {checkEventOrder: sinon.stub()}
+			"./HealthCheckManager": {check: sinon.stub()}
 		@io = {}
 		@WebsocketLoadBalancer.rclientPub = publish: sinon.stub()
 		@WebsocketLoadBalancer.rclientSub =


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

This adds a health check to the realtime `applied-ops` and `editor-events` pubsub channels, piggybacking on the existing `continualPubSubTraffic` code.  

The health check adds a unique id to each continual traffic message and checks that it is received once (only) within a timeout of 3 seconds.    If we begin to see duplicate messages (as in overleaf/sharelatex#1700) or no messages then we should restart real-time. 

It also monitors the latency of the pubsub channel as we do not currently track this.  

I have increased the frequency of the continual pubsub traffic to one message every 20 seconds, to match the default health check frequency. 

#### Screenshots

NA

#### Related Issues / PRs

overleaf/sharelatex#1700

### Review

Self-contained change mainly in `HealthCheckManager`.

#### Potential Impact

Low

#### Manual Testing Performed

- [X]  Tested in dev env with simulated errors

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [ ] Check latency graphs

#### Metrics and Monitoring

Grafana metrics for `stats.timer....event.channel.latency`

#### Who Needs to Know?


